### PR TITLE
Rename parseFormattedToEpochMilliSecond to parseFormattedToEpochMilliSeconds.

### DIFF
--- a/src/tests/util-time.test.ts
+++ b/src/tests/util-time.test.ts
@@ -3,7 +3,7 @@ import {
   nowEpochSeconds,
   nowEpochMilliSeconds,
   nowFormatted,
-  parseFormattedToEpochMilliSecond,
+  parseFormattedToEpochMilliSeconds,
   parseISO8601ToEpochMilliSeconds,
   epochMilliSecondsToSeconds,
   epochMilliSecondsToISO8601,
@@ -37,18 +37,18 @@ describe("nowFormatted", () => {
   });
 });
 
-describe("parseFormattedToEpochMilliSecond", () => {
+describe("parseFormattedToEpochMilliSeconds", () => {
   test("time and format", () => {
     const format = "yyyy-MM-ddTHH:mm:ssZ";
     const time = nowFormatted(format);
-    const res = parseFormattedToEpochMilliSecond(time, format);
+    const res = parseFormattedToEpochMilliSeconds(time, format);
     expect(res.toString().length).toBe(13);
   });
 
   test("time and format and timezone", () => {
     const format = "yyyy-MM-ddTHH:mm:ssZ";
     const time = nowFormatted(format);
-    const res = parseFormattedToEpochMilliSecond(
+    const res = parseFormattedToEpochMilliSeconds(
       time,
       format,
       "Australia/Perth"

--- a/src/util-time.ts
+++ b/src/util-time.ts
@@ -25,7 +25,7 @@ export function nowFormatted(format: string, timezone: string = "utc") {
   return moment().tz(timezone).format(vtlFormatConverted);
 }
 
-export function parseFormattedToEpochMilliSecond(
+export function parseFormattedToEpochMilliSeconds(
   time: string,
   formatFrom: string,
   timezone: string = "utc"


### PR DESCRIPTION
Hi!

I think you've made a typo in one of the util helper functions.

`parseFormattedToEpochMilliSeconds` should be plural, as per the documentation at https://docs.aws.amazon.com/appsync/latest/devguide/time-helpers-in-util-time.html

Regards,
Lennart