### PR TITLE
keep full context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export type Context = {
   request?: object;
   info?: object;
   error?: object;
-  prev?: object & { result: object };
+  prev?: object;
   stash?: Record<string, any>;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export type Context = {
   request?: object;
   info?: object;
   error?: object;
-  prev?: object & {result: object};
+  prev?: object & { result: object };
   stash?: Record<string, any>;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,14 @@ import * as map from "./util-map";
 export default class Parser {
   private template: string;
 
-  private internalStash: Record<string, string> = {};
+  private internalContext: Context;
 
-  public get stash() {
-    return this.internalStash;
+  public get stash(): Record<string, any> {
+    return this.context?.stash ?? {};
+  }
+
+  public get context(): Context {
+    return this.internalContext ?? {};
   }
 
   constructor(template: string) {
@@ -50,8 +54,8 @@ export default class Parser {
 
     const res = render(this.template, params, macros);
 
-    // Keep stash value
-    this.internalStash = clonedContext.stash;
+    // Keep the full context
+    this.internalContext = clonedContext;
 
     // Remove preceding and trailing whitespace
     const resWithoutWhitespace = res
@@ -88,8 +92,8 @@ export type Context = {
   request?: object;
   info?: object;
   error?: object;
-  prev?: object;
-  stash?: object;
+  prev?: object & {result: object};
+  stash?: Record<string, any>;
 };
 
 export type velocityParams = { [blockName: string]: boolean };

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -103,14 +103,14 @@ describe("$context keeps full context data", () => {
       expect(parser.stash).toStrictEqual({ key: { nestedKey: "nestedValue" } });
     });
 
-    describe("pre parse defaults", () => {
-      test("empty context", () => {
+    describe("Defaults if context is not defined", () => {
+      test("Context defaults to an empty object", () => {
         const parser = new Parser("");
         expect(parser.context).not.toBeUndefined();
         expect(Object.keys(parser.context).length).toEqual(0);
       });
 
-      test("empty stash", () => {
+      test("Stash defaults to an empty object", () => {
         const parser = new Parser("");
         expect(parser.stash).not.toBeUndefined();
         expect(Object.keys(parser.stash).length).toEqual(0);

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -84,14 +84,14 @@ describe("$context keeps full context data", () => {
       });
       expect(parser.stash).toStrictEqual({ key: "value" });
     });
-  
+
     test("Keep resolved data", () => {
       const vtl = '$ctx.stash.put("key", "value")';
       const parser = new Parser(vtl);
       parser.resolve({});
       expect(parser.stash).toStrictEqual({ key: "value" });
     });
-  
+
     test("Keep resolved data with complex structures", () => {
       const vtl = `
         #set($nestedMap = {})
@@ -100,22 +100,22 @@ describe("$context keeps full context data", () => {
       `;
       const parser = new Parser(vtl);
       parser.resolve({});
-      expect(parser.stash).toStrictEqual({ key: { nestedKey: "nestedValue"} });
+      expect(parser.stash).toStrictEqual({ key: { nestedKey: "nestedValue" } });
     });
 
-    describe('pre parse defaults', () => {
-      test('empty context', () => {
-        const parser = new Parser('');
+    describe("pre parse defaults", () => {
+      test("empty context", () => {
+        const parser = new Parser("");
         expect(parser.context).not.toBeUndefined();
         expect(Object.keys(parser.context).length).toEqual(0);
-      })
+      });
 
-      test('empty stash', () => {
-        const parser = new Parser('');
+      test("empty stash", () => {
+        const parser = new Parser("");
         expect(parser.stash).not.toBeUndefined();
         expect(Object.keys(parser.stash).length).toEqual(0);
-      })
-    })
+      });
+    });
   });
 
   test("Keep argument modifications", () => {
@@ -124,8 +124,11 @@ describe("$context keeps full context data", () => {
       #set($ctx.args.addition = "value")
     `;
     const parser = new Parser(vtl);
-    parser.resolve({arguments:{ original: 'foo' }})
-    expect(parser.context.arguments).toStrictEqual({ original: "bar", addition: "value" });
+    parser.resolve({ arguments: { original: "foo" } });
+    expect(parser.context.arguments).toStrictEqual({
+      original: "bar",
+      addition: "value",
+    });
   });
 });
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -74,21 +74,58 @@ test("#return returns null if called without arguments", () => {
   expect(res).toEqual(null);
 });
 
-describe("$context.stash keeps data", () => {
-  test("Keep initial data", () => {
-    const vtl = "";
-    const parser = new Parser(vtl);
-    parser.resolve({
-      stash: { key: "value" },
+describe("$context keeps full context data", () => {
+  describe("$context.stash keeps data", () => {
+    test("Keep initial data", () => {
+      const vtl = "";
+      const parser = new Parser(vtl);
+      parser.resolve({
+        stash: { key: "value" },
+      });
+      expect(parser.stash).toStrictEqual({ key: "value" });
     });
-    expect(parser.stash).toStrictEqual({ key: "value" });
+  
+    test("Keep resolved data", () => {
+      const vtl = '$ctx.stash.put("key", "value")';
+      const parser = new Parser(vtl);
+      parser.resolve({});
+      expect(parser.stash).toStrictEqual({ key: "value" });
+    });
+  
+    test("Keep resolved data with complex structures", () => {
+      const vtl = `
+        #set($nestedMap = {})
+        $util.qr($nestedMap.put("nestedKey", "nestedValue"))
+        $ctx.stash.put("key", $nestedMap)
+      `;
+      const parser = new Parser(vtl);
+      parser.resolve({});
+      expect(parser.stash).toStrictEqual({ key: { nestedKey: "nestedValue"} });
+    });
+
+    describe('pre parse defaults', () => {
+      test('empty context', () => {
+        const parser = new Parser('');
+        expect(parser.context).not.toBeUndefined();
+        expect(Object.keys(parser.context).length).toEqual(0);
+      })
+
+      test('empty stash', () => {
+        const parser = new Parser('');
+        expect(parser.stash).not.toBeUndefined();
+        expect(Object.keys(parser.stash).length).toEqual(0);
+      })
+    })
   });
 
-  test("Keep resolved data", () => {
-    const vtl = '$ctx.stash.put("key", "value")';
+  test("Keep argument modifications", () => {
+    const vtl = `
+      #set($ctx.args.original = "bar")
+      #set($ctx.args.addition = "value")
+    `;
     const parser = new Parser(vtl);
-    parser.resolve({});
-    expect(parser.stash).toStrictEqual({ key: "value" });
+    parser.resolve({arguments:{ original: 'foo' }})
+    expect(parser.context.arguments).toStrictEqual({ original: "bar", addition: "value" });
   });
 });
 


### PR DESCRIPTION
Please consider accepting this pull request to retain the full context object, extending the retention of the stash alone.

As templates can modify any part of the context, this will give us the means to verify all state updates

Additionally I added some minor type definition expansion for the Context type to hopefully better aide usage