### PR TITLE
Adds support for mock $extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,25 @@ This module supports all the provided core, map & time \$util methods, and most 
 docs](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-util-reference.html).
 
 Note: The errors list is also not returned (but \$util.error will throw an error).
+
+### Extensions
+
+AWS AppSync provides extension methods via `$extensions`, for example `$extensions.evictFromApiCache`. It can be useful to assert that your VTL template is invoking these methods, therefore, you can provide custom extensions with your own implementations. Note that default extension methods are not provided. To read more about AWS AppSync extensions see the [Extensions
+docs](https://docs.aws.amazon.com/appsync/latest/devguide/extensions.html).
+
+```javascript
+  // Given.
+  const mockEvictFromApiCache = jest.fn();
+  const parser = new Parser(`$extensions.evictFromApiCache("Query", "users", {
+    "context.arguments.id": $context.arguments.id
+  })`);
+
+  // When.
+  parser.resolve({ arguments: { id: 10 } }, undefined, {
+    evictFromApiCache: mockEvictFromApiCache,
+  });
+
+  // Then.
+  expect(mockEvictFromApiCache).toHaveBeenCalledTimes(1)
+  expect(mockEvictFromApiCache).toHaveBeenCalledWith("Query", "users", { "context.arguments.id": 10 })
+```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ AWS AppSync provides extension methods via `$extensions`, for example `$extensio
 docs](https://docs.aws.amazon.com/appsync/latest/devguide/extensions.html).
 
 ```javascript
-  // Given.
+  // Create the parser with the mock extension function
   const mockEvictFromApiCache = jest.fn();
   const parser = new Parser(`$extensions.evictFromApiCache("Query", "users", {
     "context.arguments.id": $context.arguments.id

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ docs](https://docs.aws.amazon.com/appsync/latest/devguide/extensions.html).
     "context.arguments.id": $context.arguments.id
   })`);
 
-  // When.
   parser.resolve({ arguments: { id: 10 } }, undefined, {
     evictFromApiCache: mockEvictFromApiCache,
   });

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ docs](https://docs.aws.amazon.com/appsync/latest/devguide/extensions.html).
     evictFromApiCache: mockEvictFromApiCache,
   });
 
-  // Then.
   expect(mockEvictFromApiCache).toHaveBeenCalledTimes(1)
   expect(mockEvictFromApiCache).toHaveBeenCalledWith("Query", "users", { "context.arguments.id": 10 })
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,11 @@ export default class Parser {
   /**
    * Resolve as a string
    */
-  public resolve(context: Context, additionalUtil?: object, additionalExtensions?: object): any {
+  public resolve(
+    context: Context,
+    additionalUtil?: object,
+    additionalExtensions?: object
+  ): any {
     const clonedContext = JSON.parse(JSON.stringify(context));
     if (!clonedContext.stash) clonedContext.stash = {};
     clonedContext.args = clonedContext.arguments;
@@ -40,7 +44,7 @@ export default class Parser {
       ...additionalUtil,
     };
 
-    const extensions = { ...additionalExtensions }
+    const extensions = { ...additionalExtensions };
 
     const params = {
       context: clonedContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export default class Parser {
   /**
    * Resolve as a string
    */
-  public resolve(context: Context, additionalUtil?: object): any {
+  public resolve(context: Context, additionalUtil?: object, additionalExtensions?: object): any {
     const clonedContext = JSON.parse(JSON.stringify(context));
     if (!clonedContext.stash) clonedContext.stash = {};
     clonedContext.args = clonedContext.arguments;
@@ -40,11 +40,14 @@ export default class Parser {
       ...additionalUtil,
     };
 
+    const extensions = { ...additionalExtensions }
+
     const params = {
       context: clonedContext,
       ctx: clonedContext,
       util,
       utils: util,
+      extensions,
     };
 
     const macros = {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -56,7 +56,7 @@ test("resolve with additional util", () => {
   expect(res).toEqual({ test: 10 });
 });
 
-test("resolve with additional extensions", () => {
+test("mocked extension is called", () => {
   // Given.
   const mockEvictFromApiCache = jest.fn();
   const parser = new Parser(`$extensions.evictFromApiCache("Query", "users", {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -57,7 +57,7 @@ test("resolve with additional util", () => {
 });
 
 test("mocked extension is called", () => {
-  // Given.
+  // Create the parser with the mock extension function
   const mockEvictFromApiCache = jest.fn();
   const parser = new Parser(`$extensions.evictFromApiCache("Query", "users", {
     "context.arguments.id": $context.arguments.id

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -67,7 +67,6 @@ test("mocked extension is called", () => {
     evictFromApiCache: mockEvictFromApiCache,
   });
 
-  // Then.
   expect(mockEvictFromApiCache).toHaveBeenCalledTimes(1);
   expect(mockEvictFromApiCache).toHaveBeenCalledWith("Query", "users", {
     "context.arguments.id": 10,

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -56,6 +56,23 @@ test("resolve with additional util", () => {
   expect(res).toEqual({ test: 10 });
 });
 
+test("resolve with additional extensions", () => {
+  // Given.
+  const mockEvictFromApiCache = jest.fn();
+  const parser = new Parser(`$extensions.evictFromApiCache("Query", "users", {
+    "context.arguments.id": $context.arguments.id
+  })`);
+
+  // When.
+  parser.resolve({ arguments: { id: 10 } }, undefined, {
+    evictFromApiCache: mockEvictFromApiCache,
+  });
+
+  // Then.
+  expect(mockEvictFromApiCache).toHaveBeenCalledTimes(1)
+  expect(mockEvictFromApiCache).toHaveBeenCalledWith("Query", "users", { "context.arguments.id": 10 })
+});
+
 test("#return can return an object early", () => {
   const vtl = `
   #return({"result": "A"})

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -69,8 +69,10 @@ test("resolve with additional extensions", () => {
   });
 
   // Then.
-  expect(mockEvictFromApiCache).toHaveBeenCalledTimes(1)
-  expect(mockEvictFromApiCache).toHaveBeenCalledWith("Query", "users", { "context.arguments.id": 10 })
+  expect(mockEvictFromApiCache).toHaveBeenCalledTimes(1);
+  expect(mockEvictFromApiCache).toHaveBeenCalledWith("Query", "users", {
+    "context.arguments.id": 10,
+  });
 });
 
 test("#return can return an object early", () => {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -63,7 +63,6 @@ test("mocked extension is called", () => {
     "context.arguments.id": $context.arguments.id
   })`);
 
-  // When.
   parser.resolve({ arguments: { id: 10 } }, undefined, {
     evictFromApiCache: mockEvictFromApiCache,
   });


### PR DESCRIPTION
Could support be added to this project for mocking the methods available via $extension? I am wanting to assert that $extensions.evictFromApiCache is invoked in my VTL template with the correct arguments.